### PR TITLE
Support newer PDFs downloaded from the diploma registry

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,192 +3,255 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:2efa512e2ceeda7f785a45057955b06a7ebda893b759fe4ceedad52637aad6a7"
   name = "github.com/anaskhan96/soup"
   packages = ["."]
+  pruneopts = "UT"
   revision = "00be3d730c89ee1efa038324e9bc7355ad23f93b"
 
 [[projects]]
   branch = "master"
+  digest = "1:e730c8372514c662e9ed97228c2e2023f1ec99eb68f7bb56a44c1084733d85f5"
   name = "github.com/bwesterb/byteswriter"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c31a76b641f8b94ffccad99eeeabf795e53b1e4a"
 
 [[projects]]
   branch = "master"
+  digest = "1:670b0da164df747fbf79fb31921355d9e5c81a54bfe4c3ea7b2d4ec734f088c3"
   name = "github.com/bwesterb/go-atum"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b79a6b33c09b7b8d49d2454bbde06162fdc0cd70"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2c5caf65b79d6a5b246690148a6ae89c4bd2cf1af0d8dd2370c5bb4315ef155"
   name = "github.com/bwesterb/go-pow"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b53ca488a9ca0a21ee44c6a6b0ad792693214e1a"
 
 [[projects]]
   branch = "master"
+  digest = "1:7a23a7a01a99876e516bbed346971bd09c8b5af57d3ad9b37355d74999667f0a"
   name = "github.com/bwesterb/go-xmssmt"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c7ed6207145b8af6d194cab000796a9c8ffb563a"
 
 [[projects]]
+  digest = "1:3535f00c607f3993a1a2f1cbb1b3faa3bf8903f9edc77c1386491882d3b2754c"
   name = "github.com/cespare/xxhash"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5c37fe3735342a2e0d01c87a907579987c8936cc"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:c28625428387b63dd7154eb857f51e700465cfbf7c06f619e71f2da33cefe47e"
   name = "github.com/coreos/bbolt"
   packages = ["."]
+  pruneopts = "UT"
   revision = "583e8937c61f1af6513608ccc75c97b6abdf4ff9"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:4bbe6c0a8c33a0993415aaa7197236992a3072b524173f34641ab85443550501"
   name = "github.com/credentials/safeprime"
   packages = ["."]
+  pruneopts = "UT"
   revision = "215fbc7208bf7e4a56d7bcd88735eb0c86ec5894"
 
 [[projects]]
+  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:67d0b50be0549e610017cb91e0b0b745ec0cad7c613bc8e18ff2d1c1fc8825a7"
   name = "github.com/edsrzf/mmap-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0bce6a6887123b67a60366d2c9fe2dfb74289d2e"
 
 [[projects]]
+  digest = "1:aacef5f5e45685f2aeda5534d0a750dee6859de7e9088cdd06192787bb01ae6d"
   name = "github.com/go-errors/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
   branch = "master"
+  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
 
 [[projects]]
   branch = "master"
+  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
 
 [[projects]]
   branch = "master"
+  digest = "1:0718a9f0855a7dd747abd0fa17b666cbf8d200447813cd7cfa8c47c886f99ae7"
   name = "github.com/mastahyeti/cms"
   packages = [
     ".",
     "oid",
     "protocol",
-    "timestamp"
+    "timestamp",
   ]
-  revision = "140c79d1208656095b7024bf9e9cc9b1b253d434"
+  pruneopts = "UT"
+  revision = "ec6fafdd655a614d13a9336ea483e37d51a11752"
 
 [[projects]]
   branch = "master"
+  digest = "1:ef35e43a113abe235855614390b86d6d6d5160e54322f081b56dba87223639da"
   name = "github.com/mhe/gabi"
   packages = ["."]
+  pruneopts = "UT"
   revision = "78bc0716eb6d1d825c7bb16615986e24c902cee3"
 
 [[projects]]
   branch = "master"
+  digest = "1:6491080aa184f88c2bb8e2f6056e5e0e9a578b2d8666efbd6e97bc37a0c41e72"
   name = "github.com/nightlyone/lockfile"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0ad87eef1443f64d3d8c50da647e2b1552851124"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "aykevl-jwt2"
+  digest = "1:8e35bf745754d8e9e66c8d7d3fa31673f990cf3a7ff36b28310891a3c458a99e"
   name = "github.com/privacybydesign/irmago"
   packages = [
     ".",
     "internal/disable_sigpipe",
-    "internal/fs"
+    "internal/fs",
   ]
+  pruneopts = "UT"
   revision = "e95d673380277eb5e2177610d5e1a0964435ee60"
 
 [[projects]]
   branch = "master"
+  digest = "1:abab2c85a12689a4218964335aa990ff33b4f3c7ba48e3283861c4714d2e93b1"
   name = "github.com/rainycape/dl"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1b01514224a1a60a6bcbb0b6b9d3a00ec14ae17f"
 
 [[projects]]
   branch = "master"
+  digest = "1:f10bb2efe706eea8e386fa5021281e302a58e8fa0ba9f2e31ad9ca2cb234b282"
   name = "github.com/templexxx/cpufeat"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cef66df7f161dee20f4d650da7268d77eaaec82d"
 
 [[projects]]
+  digest = "1:a0a269bea865974fc4d583373c984a5aa60cf98b5aa4f3e1b5de527891d37845"
   name = "github.com/templexxx/xor"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0af8e873c554da75f37f2049cdffda804533d44c"
   version = "0.1.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:f1bcadef588162241008b4806b1f2a9c92153cf442fd3d9ad3bc879518a5a824"
   name = "github.com/timshannon/bolthold"
   packages = ["."]
+  pruneopts = "UT"
   revision = "525de816b1a2c1cfbb67b5e9936a6b76e0c7f3e6"
 
 [[projects]]
   branch = "master"
+  digest = "1:6d70356d298e4f9ea5974ea626f1ca81402189a3de7aa9d14617e0cc04b8f838"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
     "ed25519/internal/edwards25519",
-    "sha3"
+    "sha3",
   ]
+  pruneopts = "UT"
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ef52fe3c5134f18540c4ca5ee70c57f14a3c85b21e05867f0e793de006169a6"
   name = "golang.org/x/net"
   packages = [
     "html",
-    "html/atom"
+    "html/atom",
   ]
+  pruneopts = "UT"
   revision = "c39426892332e1bb5ec0a434a079bf82f5d30c54"
 
 [[projects]]
   branch = "master"
+  digest = "1:0316a8ad208917f1d141b077e278980fd5e4594f3a85f835dacbf24d85798252"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "14742f9018cd6651ec7364dc6ee08af0baaa1031"
 
 [[projects]]
   branch = "ignore-identity-encryption"
+  digest = "1:64937028ce83ffd5bac56ed16c455e48b9b5258aad78b82f196e8d0f07efc2a4"
   name = "rsc.io/pdf"
   packages = ["."]
+  pruneopts = "UT"
   revision = "03f2f489cec0738d12038e5909dde3fba84f68db"
   source = "github.com/aykevl/pdf"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "920e756fc5cfd34293a944501596efc7da346a6ebcca210e38cce5871e97acdd"
+  input-imports = [
+    "github.com/anaskhan96/soup",
+    "github.com/mastahyeti/cms",
+    "github.com/mastahyeti/cms/protocol",
+    "github.com/privacybydesign/irmago",
+    "golang.org/x/net/html",
+    "rsc.io/pdf",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
These newer PDFs use so-called "detached" signatures (`adbe.pkcs7.detached`) instead of plain SHA1 based signatures (`adbe.pkcs7.sha1`). This is better as they don't rely on SHA1 anymore, but needs some support. Also, the package github.com/mastahyeti/cms needed to be updated for these detached signatures to be fully supported.